### PR TITLE
Changed line ending matching to improve compatibility on windows

### DIFF
--- a/src/org/docopt/Docopt.hx
+++ b/src/org/docopt/Docopt.hx
@@ -484,7 +484,7 @@ class Docopt {
     name:String, source:String
   ):Array<String> {
     var pattern = new EReg(
-        "^([^\\n]*" + name + "[^\\n]*\\n?(?:[ \\t].*?(?:\\n|$))*)", "im"
+        "^([^\\r\\n]*" + name + "[^\\r\\n]*\\r?\\n?(?:[ \\t].*?(?:\\r?\\n|$))*)", "im"
       );
     return [ for (s in regAll(pattern, source)) s.trim() ];
   }


### PR DESCRIPTION
I've run into issues caused by the different line endings on windows. I've had to change the way that line endings are matched to fix this. I can confirm that this fix works on mac as well.